### PR TITLE
Add option to read xml string

### DIFF
--- a/example/dual_arm.py
+++ b/example/dual_arm.py
@@ -127,7 +127,7 @@ class DualKukaPlanner:
         cwd = pathlib.Path(__file__).parent.resolve() # path to current working directory
         urdf_filename = os.path.join(cwd, 'robots', 'kuka_lwr.urdf')
         model = optas.RobotModel(
-            urdf_filename,
+            urdf_filename=urdf_filename,
             name=name,
             time_derivs=[0, 1],  # i.e. joint position/velocity trajectory
         )

--- a/example/figure_eight_plan.py
+++ b/example/figure_eight_plan.py
@@ -30,7 +30,7 @@ class Planner:
         # Setup robot
         urdf_filename = os.path.join(cwd, 'robots', 'kuka_lwr.urdf')
         self.kuka = optas.RobotModel(
-            urdf_filename,
+            urdf_filename=urdf_filename,
             time_derivs=[0, 1],  # i.e. joint position/velocity trajectory
         )
         self.kuka_name = self.kuka.get_name()

--- a/experiments/expr1.py
+++ b/experiments/expr1.py
@@ -140,7 +140,7 @@ class Experiment:
 
 
     def __init__(self, config):
-        self.robot = optas.RobotModel(config.urdf, time_derivs=[1])
+        self.robot = optas.RobotModel(urdf_filename=config.urdf, time_derivs=[1])
         self.eff_pos = self.robot.get_global_link_position_function(config.eff_link, n=self.N+1)
         self.q0 = optas.vec(optas.np.deg2rad(config.q0))
         self.ik1 = IK1(self.robot, config.eff_link).setup_problem(config.xydir, self.dt).setup_solver()

--- a/experiments/expr2.py
+++ b/experiments/expr2.py
@@ -26,7 +26,7 @@ if not os.path.exists(exprdir):
 pi = optas.np.pi
 urdf = os.path.join(path, 'robots', 'kuka_lwr', 'kuka_lwr.urdf')
 ee_link = "end_effector_ball"
-robot = optas.RobotModel(urdf, time_derivs=[0, 1])
+robot = optas.RobotModel(urdf_filename=urdf, time_derivs=[0, 1])
 pos = robot.get_global_link_position_function(ee_link)
 q0 = optas.np.deg2rad([0, 30, 0, -90, 0, -30, 0])
 Tr = robot.get_global_link_transform_function(ee_link)
@@ -67,7 +67,7 @@ class OpTaSIK(ExprIK):
         super().__init__()
 
         # Setup
-        robot = optas.RobotModel(urdf, time_derivs=[0])
+        robot = optas.RobotModel(urdf_filename=urdf, time_derivs=[0])
         self.name = robot.get_name()
         builder = optas.OptimizationBuilder(T=1, robots=[robot])
         qc = builder.add_parameter('qc', robot.ndof)

--- a/optas/models.py
+++ b/optas/models.py
@@ -87,10 +87,15 @@ class JointTypeNotSupported(NotImplementedError):
 class RobotModel(Model):
 
 
-    def __init__(self, urdf_filename, name=None, time_derivs=[0], qddlim=None):
+    def __init__(self, urdf_filename=None, urdf_string=None, name=None, time_derivs=[0], qddlim=None):
 
         # Load URDF
-        self._urdf = URDF.from_xml_file(urdf_filename)
+        self._urdf = None
+        if(urdf_filename!=None):
+            self._urdf = URDF.from_xml_file(urdf_filename)
+        if(urdf_string!=None):
+            self._urdf = URDF.from_xml_string(urdf_string)
+        assert self._urdf is not None, "You need to supply a urdf, either through filename or as a string"
 
         # Setup joint limits, joint position/velocity limits
         dlim = {


### PR DESCRIPTION
I changed the way to initialize the RobotModel class to instead of by default having only option for urdf_filename, now one can either include urdf_filename=... or urdf_string=...

`    def __init__(self, urdf_filename=None, urdf_string=None, name=None, time_derivs=[0], qddlim=None):`

This is because when using this within ROS we should use the robot_description parameter to get the xml string and do not have to specify paths inside of the file - that should only belong to the launch file.

I changed all the examples in the repo to use this option now.

Check if there is a better way to be able to initialize the class from either filename of string.

Note: forgot to delete a commented out assert in my edit - i didn't want to have to add another commit just because of this.