### PR TITLE
Enable user to specify functions that always output numpy arrays

### DIFF
--- a/optas/models.py
+++ b/optas/models.py
@@ -812,6 +812,9 @@ class RobotModel(Model):
                     return self.handle(self.F(q).toarray())
 
                 def __call__(self, q):
+                    assert not isinstance(
+                        q, cs.SX
+                    ), "numpy_output=False was specified, you can not pass symbolic variables"
                     return self.call(q)
 
             F = NumpyOutputFunction(F)

--- a/optas/models.py
+++ b/optas/models.py
@@ -872,6 +872,7 @@ class RobotModel(Model):
 
         @param link Name of the end-effector link.
         @param n Number of joint states to expect when the function is called. Default is 1.
+        @param numpy_output When true, the output will be a NumPy array.
         @return A CasADi function that computes the transform for a given joint state. If n > 1 then a list of transform are given for each corresponding joint state.
         """
         return self.make_function(
@@ -906,6 +907,7 @@ class RobotModel(Model):
         @param link Name of the end-effector link.
         @param base_link Name of the base frame link.
         @param n Number of joint states to expect when the function is called. Default is 1.
+        @param numpy_output When true, the output will be a NumPy array.
         @return A CasADi function that computes the transform for a given joint state. If n > 1 then a list of transform are given for each corresponding joint state.
         """
         return self.make_function(
@@ -935,6 +937,7 @@ class RobotModel(Model):
 
         @param link Name of the end-effector link.
         @param n Number of joint states to expect when the function is called. Default is 1.
+        @param numpy_output When true, the output will be a NumPy array.
         @return A CasADi function that computes the position for a given joint state. If n > 1 then an array is computed whose columns each correspond to the respective joint state in the input.
         """
         return self.make_function(
@@ -966,6 +969,7 @@ class RobotModel(Model):
         @param link Name of the end-effector link.
         @param base_link Name of the base frame link.
         @param n Number of joint states to expect when the function is called. Default is 1.
+        @param numpy_output When true, the output will be a NumPy array.
         @return A CasADi function that computes the position for a given joint state. If n > 1 then an array is computed whose columns each correspond to the respective joint state in the input.
         """
         return self.make_function(
@@ -995,6 +999,7 @@ class RobotModel(Model):
 
         @param link Name of the end-effector link.
         @param n Number of joint states to expect when the function is called. Default is 1.
+        @param numpy_output When true, the output will be a NumPy array.
         @return A CasADi function that computes the rotation for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
         """
         return self.make_function(
@@ -1027,6 +1032,7 @@ class RobotModel(Model):
         @param link Name of the end-effector link.
         @param base_link Name of the base frame link.
         @param n Number of joint states to expect when the function is called. Default is 1.
+        @param numpy_output When true, the output will be a NumPy array.
         @return A CasADi function that computes the rotation for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
         """
         return self.make_function(
@@ -1086,6 +1092,7 @@ class RobotModel(Model):
 
         @param link Name of the end-effector link.
         @param n Number of joint states to expect when the function is called. Default is 1.
+        @param numpy_output When true, the output will be a NumPy array.
         @return A CasADi function that computes the quaternion for a given joint state. If n > 1 then an array is computed whose columns correspond to the respective joint state in the input.
         """
         return self.make_function(
@@ -1124,6 +1131,7 @@ class RobotModel(Model):
         @param link Name of the end-effector link.
         @param base_link Name of the base frame link.
         @param n Number of joint states to expect when the function is called. Default is 1.
+        @param numpy_output When true, the output will be a NumPy array.
         @return A CasADi function that computes the quaternion for a given joint state. If n > 1 then an array is computed whose columns correspond to the respective joint state in the input.
         """
         return self.make_function(
@@ -1174,6 +1182,7 @@ class RobotModel(Model):
         @param link Name of the end-effector link.
         @param base_link Name of the base frame link.
         @param n Number of joint states to expect when the function is called. Default is 1.
+        @param numpy_output When true, the output will be a NumPy array.
         @return A CasADi function that computes the RPY angles for a given joint state. If n > 1 then an array is computed whose columns correspond to the respective joint state in the input.
         """
         return self.make_function(
@@ -1274,6 +1283,7 @@ class RobotModel(Model):
 
         @param link Name of the end-effector link.
         @param n Number of joint states to expect when the function is called. Default is 1.
+        @param numpy_output When true, the output will be a NumPy array.
         @return A CasADi function that computes the geometric jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
         """
         return self.make_function(
@@ -1316,6 +1326,7 @@ class RobotModel(Model):
 
         @param link Name of the end-effector link.
         @param n Number of joint states to expect when the function is called. Default is 1.
+        @param numpy_output When true, the output will be a NumPy array.
         @return A CasADi function that computes the analytic jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
         """
         return self.make_function(
@@ -1374,6 +1385,7 @@ class RobotModel(Model):
         @param link Name of the end-effector link.
         @param base_link Name of the base frame link.
         @param n Number of joint states to expect when the function is called. Default is 1.
+        @param numpy_output When true, the output will be a NumPy array.
         @return A CasADi function that computes the geometric jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
         """
         return self.make_function(
@@ -1424,6 +1436,7 @@ class RobotModel(Model):
         @param link Name of the end-effector link.
         @param base_link Name of the base frame link.
         @param n Number of joint states to expect when the function is called. Default is 1.
+        @param numpy_output When true, the output will be a NumPy array.
         @return A CasADi function that computes the analytic jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
         """
         return self.make_function(
@@ -1469,6 +1482,7 @@ class RobotModel(Model):
 
         @param link Name of the end-effector link.
         @param n Number of joint states to expect when the function is called. Default is 1.
+        @param numpy_output When true, the output will be a NumPy array.
         @return A CasADi function that computes the linear part of the Jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
         """
         return self.make_function(
@@ -1512,6 +1526,7 @@ class RobotModel(Model):
         @param link Name of the end-effector link.
         @param base_link Name of the base frame link.
         @param n Number of joint states to expect when the function is called. Default is 1.
+        @param numpy_output When true, the output will be a NumPy array.
         @return A CasADi function that computes the linear part of the Jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
         """
         return self.make_function(
@@ -1558,6 +1573,7 @@ class RobotModel(Model):
 
         @param link Name of the end-effector link.
         @param n Number of joint states to expect when the function is called. Default is 1.
+        @param numpy_output When true, the output will be a NumPy array.
         @return A CasADi function that computes the angular part of the geometric Jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
         """
         return self.make_function(
@@ -1601,6 +1617,7 @@ class RobotModel(Model):
 
         @param link Name of the end-effector link.
         @param n Number of joint states to expect when the function is called. Default is 1.
+        @param numpy_output When true, the output will be a NumPy array.
         @return A CasADi function that computes the angular part of the geometric Jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
         """
         return self.make_function(
@@ -1648,6 +1665,7 @@ class RobotModel(Model):
         @param link Name of the end-effector link.
         @param base_link Name of the base frame link.
         @param n Number of joint states to expect when the function is called. Default is 1.
+        @param numpy_output When true, the output will be a NumPy array.
         @return A CasADi function that computes the angular part of the geometric Jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
         """
         return self.make_function(
@@ -1704,6 +1722,7 @@ class RobotModel(Model):
         @param link Name of the end-effector link.
         @param base_link Name of the base frame link.
         @param n Number of joint states to expect when the function is called. Default is 1.
+        @param numpy_output When true, the output will be a NumPy array.
         @return A CasADi function that computes the angular part of the analytical Jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
         """
         return self.make_function(
@@ -1763,6 +1782,7 @@ class RobotModel(Model):
         @param link Name of the end-effector link.
         @param axis The axis (direction vector) defined in the end-effector frame. If 'x', 'y', 'z' is passed then the corresponding sub-array of the homogenous transform is used.
         @param base_link Name of the base frame link.
+        @param numpy_output When true, the output will be a NumPy array.
         @return A CasADi function that computes the link axis for a given joint state. If n > 1 then an array is computed whose columns correspond to the respective joint state in the input.
         """
         return self.make_function(
@@ -1800,6 +1820,7 @@ class RobotModel(Model):
 
         @param link Name of the end-effector link.
         @param axis The axis (direction vector) defined in the end-effector frame. If 'x', 'y', 'z' is passed then the corresponding sub-array of the homogenous transform is used.
+        @param numpy_output When true, the output will be a NumPy array.
         @return A CasADi function that computes the link axis for a given joint state. If n > 1 then an array is computed whose columns correspond to the respective joint state in the input.
         """
         get_global_link_axis = functools.partial(self.get_global_link_axis, axis=axis)

--- a/optas/models.py
+++ b/optas/models.py
@@ -21,7 +21,7 @@ from .spatialmath import *
 def listify_output(fun: Callable) -> Callable:
     """! Decorator that handles the output of Model methods.
 
-    @param fun A method from a Model sub-class.
+@param fun A method from a Model sub-class.
     """
 
     @functools.wraps(fun)
@@ -93,14 +93,14 @@ class Model:
     ):
         """! The Model base class initializer.
 
-        @param name The name of the model.
-        @param dim Model dimension (for robots this is ndof).
-        @param time_derivs Time derivatives required for model, 0 means not time derivative, 1 means first derivative wrt to time is required, etc.
-        @param symbol A short symbol to represent the model.
-        @param dlim Limits on each time derivative, index should correspond to a time derivative (i.e. 0, 1, ...) and the value should be a tuple of two lists containing the lower and upper bounds.
-        @param T Optionally use this to override the number of time-steps given in the OptimizationBuilder constructor.
+@param name The name of the model.
+@param dim Model dimension (for robots this is ndof).
+@param time_derivs Time derivatives required for model, 0 means not time derivative, 1 means first derivative wrt to time is required, etc.
+@param symbol A short symbol to represent the model.
+@param dlim Limits on each time derivative, index should correspond to a time derivative (i.e. 0, 1, ...) and the value should be a tuple of two lists containing the lower and upper bounds.
+@param T Optionally use this to override the number of time-steps given in the OptimizationBuilder constructor.
 
-        @return An instance of the Model class.
+@return An instance of the Model class.
         """
 
         ## The name of the model.
@@ -124,15 +124,15 @@ class Model:
     def get_name(self) -> str:
         """! Return the name of the model.
 
-        @return Name of the model.
+@return Name of the model.
         """
         return self.name
 
     def state_name(self, time_deriv: int) -> str:
         """! Return the state name.
 
-        @param time_deriv The time-deriviative required (i.e. position is 0, velocity is 1, etc.)
-        @return The state name in the form {name}/{d}{symbol}, where "name" is the model name, d is a string given by 'd'*time_deriv, and symbol is the symbol for the model state.
+@param time_deriv The time-deriviative required (i.e. position is 0, velocity is 1, etc.)
+@return The state name in the form {name}/{d}{symbol}, where "name" is the model name, d is a string given by 'd'*time_deriv, and symbol is the symbol for the model state.
         """
         assert (
             time_deriv in self.time_derivs
@@ -142,8 +142,8 @@ class Model:
     def state_parameter_name(self, time_deriv: int) -> str:
         """! Return the parameter name.
 
-        @param time_deriv The time-deriviative required (i.e. position is 0, velocity is 1, etc.)
-        @return The parameter name in the form {name}/{d}{symbol}/p, where "name" is the model name, d is a string given by 'd'*time_deriv, and symbol is the symbol for the model parameters.
+@param time_deriv The time-deriviative required (i.e. position is 0, velocity is 1, etc.)
+@return The parameter name in the form {name}/{d}{symbol}/p, where "name" is the model name, d is a string given by 'd'*time_deriv, and symbol is the symbol for the model parameters.
         """
         assert (
             time_deriv in self.time_derivs
@@ -153,8 +153,8 @@ class Model:
     def state_optimized_name(self, time_deriv: int) -> str:
         """! Return the sate optimized name.
 
-        @param time_deriv The time-deriviative required (i.e. position is 0, velocity is 1, etc.)
-        @return The parameter name in the form {name}/{d}{symbol_param}/x, where "name" is the model name, d is a string given by 'd'*time_deriv, and symbol_param is the symbol for the model parameters.
+@param time_deriv The time-deriviative required (i.e. position is 0, velocity is 1, etc.)
+@return The parameter name in the form {name}/{d}{symbol_param}/x, where "name" is the model name, d is a string given by 'd'*time_deriv, and symbol_param is the symbol for the model parameters.
         """
         assert (
             time_deriv in self.time_derivs
@@ -164,9 +164,9 @@ class Model:
     def get_limits(self, time_deriv: int) -> Tuple[ArrayType]:
         """! Return the model limits.
 
-        @param time_deriv The time-deriviative required (i.e. position is 0, velocity is 1, etc.)
-        @return lower The model lower limit.
-        @return upper The model upper limit.
+@param time_deriv The time-deriviative required (i.e. position is 0, velocity is 1, etc.)
+@return lower The model lower limit.
+@return upper The model upper limit.
         """
         assert (
             time_deriv in self.time_derivs
@@ -179,9 +179,9 @@ class Model:
     def in_limit(self, x: ArrayType, time_deriv: int) -> cs.DM:
         """! Check if array is within model limits.
 
-        @param x The array containing values to be checked.
-        @param time_deriv The time-deriviative required (i.e. position is 0, velocity is 1, etc.)
-        @return Returns DM(1) if the array x is within the model limits, DM(0) otherwise.
+@param x The array containing values to be checked.
+@param time_deriv The time-deriviative required (i.e. position is 0, velocity is 1, etc.)
+@return Returns DM(1) if the array x is within the model limits, DM(0) otherwise.
         """
         lo, up = self.get_limits(time_deriv)
         return cs.logic_all(cs.logic_and(lo <= x, x <= up))
@@ -201,12 +201,12 @@ class TaskModel(Model):
     ):
         """! Task model initializer.
 
-        @param name The name of the model.
-        @param dim Model dimension.
-        @param time_derivs Time derivatives required for model, 0 means not time derivative, 1 means first derivative wrt to time is required, etc.
-        @param symbol A short symbol to represent the model.
-        @param dlim Limits on each time derivative, index should correspond to a time derivative (i.e. 0, 1, ...) and the value should be a tuple of two lists containing the lower and upper bounds.
-        @param T Optionally use this to override the number of time-steps given in the OptimizationBuilder constructor.
+@param name The name of the model.
+@param dim Model dimension.
+@param time_derivs Time derivatives required for model, 0 means not time derivative, 1 means first derivative wrt to time is required, etc.
+@param symbol A short symbol to represent the model.
+@param dlim Limits on each time derivative, index should correspond to a time derivative (i.e. 0, 1, ...) and the value should be a tuple of two lists containing the lower and upper bounds.
+@param T Optionally use this to override the number of time-steps given in the OptimizationBuilder constructor.
         """
 
         super().__init__(name, dim, time_derivs, symbol, dlim, T)
@@ -218,8 +218,8 @@ class JointTypeNotSupported(NotImplementedError):
     def __init__(self, joint_type: str):
         """! Initializer for the JointTypeNotSupported exception.
 
-        @param joint_type The joint type given
-        @return An instance of the exception class.
+@param joint_type The joint type given
+@return An instance of the exception class.
         """
 
         msg = f"{joint_type} joints are currently not supported\n"
@@ -246,14 +246,14 @@ class RobotModel(Model):
 
         Note, at least one of the parameters urdf_filename, urdf_string, or xacro_filename must be specified.
 
-        @param urdf_filename Filename for a URDF.
-        @param urdf_string URDF as a string.
-        @param xacro_filename Filename for a xacro file.
-        @param name Name of the robot model.
-        @param time_derivs Time derivatives required for model, 0 means not time derivative, 1 means first derivative wrt to time is required, etc.
-        @param qddlim Optionally specify limits on the joint acceleration.
-        @param T Optionally use this to override the number of time-steps given in the OptimizationBuilder constructor.
-        @param param_joints A list of joints that are considered parameters.
+@param urdf_filename Filename for a URDF.
+@param urdf_string URDF as a string.
+@param xacro_filename Filename for a xacro file.
+@param name Name of the robot model.
+@param time_derivs Time derivatives required for model, 0 means not time derivative, 1 means first derivative wrt to time is required, etc.
+@param qddlim Optionally specify limits on the joint acceleration.
+@param T Optionally use this to override the number of time-steps given in the OptimizationBuilder constructor.
+@param param_joints A list of joints that are considered parameters.
         """
 
         # If xacro is passed then convert to urdf string
@@ -331,7 +331,7 @@ class RobotModel(Model):
     def joint_names(self) -> List[str]:
         """! Property that gives the list of joint names.
 
-        @return List of joint names.
+@return List of joint names.
         """
         return [jnt.name for jnt in self.urdf.joints]
 
@@ -339,7 +339,7 @@ class RobotModel(Model):
     def link_names(self) -> List[str]:
         """! Property that gives the list of link names.
 
-        @return List of link names.
+@return List of link names.
         """
         return [lnk.name for lnk in self.urdf.links]
 
@@ -347,7 +347,7 @@ class RobotModel(Model):
     def actuated_joint_names(self) -> List[str]:
         """! Property that gives the names of the actuated joints.
 
-        @return List of actuated joint names.
+@return List of actuated joint names.
         """
         return [jnt.name for jnt in self.urdf.joints if jnt.type != "fixed"]
 
@@ -355,7 +355,7 @@ class RobotModel(Model):
     def parameter_joint_names(self) -> List[str]:
         """! Property that gives the names of the parameterized joints.
 
-        @return List of the parameterized joint names.
+@return List of the parameterized joint names.
         """
         return [
             joint for joint in self.actuated_joint_names if joint in self.param_joints
@@ -365,7 +365,7 @@ class RobotModel(Model):
     def optimized_joint_indexes(self) -> List[int]:
         """! Property that gives the indexes of the optimized joints.
 
-        @return List of the optimized joint indexes.
+@return List of the optimized joint indexes.
         """
         return [
             self.get_actuated_joint_index(joint) for joint in self.optimized_joint_names
@@ -375,7 +375,7 @@ class RobotModel(Model):
     def optimized_joint_names(self) -> List[str]:
         """! Property that gives the names of the optimized joints names.
 
-        @return List of the optimized joint names.
+@return List of the optimized joint names.
         """
         return [
             joint
@@ -387,7 +387,7 @@ class RobotModel(Model):
     def parameter_joint_indexes(self) -> List[int]:
         """! Property that gives the indexes of the parameterized joints.
 
-        @return List of the parameterized joint indexes.
+@return List of the parameterized joint indexes.
         """
         return [
             self.get_actuated_joint_index(joint) for joint in self.parameter_joint_names
@@ -396,16 +396,16 @@ class RobotModel(Model):
     def extract_parameter_dimensions(self, values: ArrayType) -> ArrayType:
         """! Return the elements that correspond to the model dimensions.
 
-        @param values The values to extract elements from.
-        @return A sub-array of the given values corresponding to the model parameterized dimension.
+@param values The values to extract elements from.
+@return A sub-array of the given values corresponding to the model parameterized dimension.
         """
         return values[self.parameter_joint_indexes, :]
 
     def extract_optimized_dimensions(self, values: ArrayType) -> ArrayType:
         """! Return the elements that correspond to the model optimized dimensions.
 
-        @param values The values to extract elements from.
-        @return A sub-array of the given values corresponding to the model optimized dimensions.
+@param values The values to extract elements from.
+@return A sub-array of the given values corresponding to the model optimized dimensions.
         """
         return values[self.optimized_joint_indexes, :]
 
@@ -413,7 +413,7 @@ class RobotModel(Model):
     def ndof(self) -> int:
         """! Number of degrees of freedom.
 
-        @return The number of degrees of freedom for the robot.
+@return The number of degrees of freedom for the robot.
         """
         return len(self.actuated_joint_names)
 
@@ -421,7 +421,7 @@ class RobotModel(Model):
     def num_opt_joints(self) -> int:
         """! Number of optimized joints.
 
-        @return The number of optimized joints.
+@return The number of optimized joints.
         """
         return len(self.optimized_joint_names)
 
@@ -429,15 +429,15 @@ class RobotModel(Model):
     def num_param_joints(self) -> int:
         """! Number of parameterized joints.
 
-        @return The number of parameterized joints.
+@return The number of parameterized joints.
         """
         return len(self.parameter_joint_names)
 
     def get_joint_lower_limit(self, joint: Joint) -> float:
         """! Return the lower limit for a given joint.
 
-        @param joint The joint instance from the URDF.
-        @return The lower limit, when undefined the value -1e9 is returned.
+@param joint The joint instance from the URDF.
+@return The lower limit, when undefined the value -1e9 is returned.
         """
         if joint.limit is None:
             return -1e9
@@ -446,8 +446,8 @@ class RobotModel(Model):
     def get_joint_upper_limit(self, joint: Joint) -> float:
         """! Return the upper limit for a given joint.
 
-        @param joint The joint instance from the URDF.
-        @return The upper limit, when undefined the value 1e9 is returned.
+@param joint The joint instance from the URDF.
+@return The upper limit, when undefined the value 1e9 is returned.
         """
         if joint.limit is None:
             return 1e9
@@ -456,8 +456,8 @@ class RobotModel(Model):
     def get_velocity_joint_limit(self, joint: Joint) -> float:
         """! Return the velocity limit for a given joint.
 
-        @param joint The joint instance from the URDF.
-        @return The velocity limit, when undefined the value 1e9 is returned.
+@param joint The joint instance from the URDF.
+@return The velocity limit, when undefined the value 1e9 is returned.
         """
         if joint.limit is None:
             return 1e9
@@ -467,7 +467,7 @@ class RobotModel(Model):
     def lower_actuated_joint_limits(self) -> cs.DM:
         """! Property that defines the lower actuated joint limits.
 
-        @return The lower joint position limits.
+@return The lower joint position limits.
         """
         return cs.DM(
             [
@@ -481,7 +481,7 @@ class RobotModel(Model):
     def upper_actuated_joint_limits(self) -> cs.DM:
         """! Property that defines the upper actuated joint limits.
 
-        @return The upper joint position limits.
+@return The upper joint position limits.
         """
         return cs.DM(
             [
@@ -495,7 +495,7 @@ class RobotModel(Model):
     def velocity_actuated_joint_limits(self) -> cs.DM:
         """! Property that defines the velocity actuated joint limits.
 
-        @return The velocity joint limits.
+@return The velocity joint limits.
         """
         return cs.DM(
             [
@@ -509,7 +509,7 @@ class RobotModel(Model):
     def lower_optimized_joint_limits(self) -> cs.DM:
         """! Property that defines the lower optimized joint limits.
 
-        @return The lower joint position limits.
+@return The lower joint position limits.
         """
         return cs.DM(
             [
@@ -523,7 +523,7 @@ class RobotModel(Model):
     def upper_optimized_joint_limits(self) -> cs.DM:
         """! Property that defines the upper optimized joint limits.
 
-        @return The upper joint position limits.
+@return The upper joint position limits.
         """
         return cs.DM(
             [
@@ -537,7 +537,7 @@ class RobotModel(Model):
     def velocity_optimized_joint_limits(self) -> cs.DM:
         """! Property that defines the velocity limits for the optimized joints.
 
-        @return The joint velocity limits.
+@return The joint velocity limits.
         """
         return cs.DM(
             [
@@ -556,10 +556,10 @@ class RobotModel(Model):
     ) -> None:
         """! Add new base frame, note this changes the root link.
 
-        @param base_link The name for the new root link.
-        @param xyz The position of the new link with respect to the current root link. Defaults to [0.0, 0.0, 0.0].
-        @param rpy The orientation as Euler (RPY) angles, defined in radians, with respect to the current root link. Defaults to [0.0, 0.0, 0.0].
-        @param joint_name The name for the joint that connects the current root link with the new base frame. Defaults to "{base_link}_and_{current_root_link}_joint".
+@param base_link The name for the new root link.
+@param xyz The position of the new link with respect to the current root link. Defaults to [0.0, 0.0, 0.0].
+@param rpy The orientation as Euler (RPY) angles, defined in radians, with respect to the current root link. Defaults to [0.0, 0.0, 0.0].
+@param joint_name The name for the joint that connects the current root link with the new base frame. Defaults to "{base_link}_and_{current_root_link}_joint".
         """
 
         parent_link = base_link
@@ -620,15 +620,15 @@ class RobotModel(Model):
     def get_root_link(self) -> str:
         """! The root link name.
 
-        @return The name of the root link.
+@return The name of the root link.
         """
         return self.urdf.get_root()
 
     def get_link_visual_origin(self, link: Link) -> Tuple[cs.DM]:
         """! Get the link position and orientation for the link visual.
 
-        @param link The link of interest.
-        @return The position and orientation.
+@param link The link of interest.
+@return The position and orientation.
         """
         xyz, rpy = cs.DM.zeros(3), cs.DM.zeros(3)
         if link.visual is not None:
@@ -640,8 +640,8 @@ class RobotModel(Model):
     def get_joint_origin(self, joint: Joint) -> Tuple[cs.DM]:
         """! Get the origin for the joint.
 
-        @param The joint of interest.
-        @return The position and orientation of the joint.
+@param The joint of interest.
+@return The position and orientation of the joint.
         """
         xyz, rpy = cs.DM.zeros(3), cs.DM.zeros(3)
         if joint.origin is not None:
@@ -651,16 +651,16 @@ class RobotModel(Model):
     def get_joint_axis(self, joint: Joint) -> cs.DM:
         """! Get the axis of a joint.
 
-        @param The joint of interest.
-        @return The normalized joint axis."""
+@param The joint of interest.
+@return The normalized joint axis."""
         axis = cs.DM(joint.axis) if joint.axis is not None else cs.DM([1.0, 0.0, 0.0])
         return unit(axis)
 
     def get_actuated_joint_index(self, joint_name: str) -> int:
         """! Get the joint index for a given joint name.
 
-        @param The name of the joint.
-        @return Index for the joint.
+@param The name of the joint.
+@return Index for the joint.
         """
         return self.actuated_joint_names.index(joint_name)
 
@@ -674,12 +674,12 @@ class RobotModel(Model):
     ) -> cs.DM:
         """! Random joint positions within actuator limits and optionally within a box for a given base link.
 
-        @param n Number of joint positions. Default is 1.
-        @param xlim Limit the robot link positions in the x axis for the base frame. None means there are no limits.
-        @param ylim Limit the robot link positions in the y axis for the base frame. None means there are no limits.
-        @param zlim Limit the robot link positions in the z axis for the base frame. None means there are no limits.
-        @param base_link The link to define the x, y, z limits. None means the root link is used.
-        @return Random joint positions with dimension ndof-by-n.
+@param n Number of joint positions. Default is 1.
+@param xlim Limit the robot link positions in the x axis for the base frame. None means there are no limits.
+@param ylim Limit the robot link positions in the y axis for the base frame. None means there are no limits.
+@param zlim Limit the robot link positions in the z axis for the base frame. None means there are no limits.
+@param base_link The link to define the x, y, z limits. None means the root link is used.
+@return Random joint positions with dimension ndof-by-n.
         """
 
         lo = self.lower_actuated_joint_limits.toarray()
@@ -718,8 +718,8 @@ class RobotModel(Model):
     def get_random_pose_in_global_link(self, link_name: str) -> cs.DM:
         """Random end-effector pose within robot limits.
 
-        @param link_name Name of the end-effector link.
-        @return Random homogeneous transformation array within robot limits defined in the global link frame.
+@param link_name Name of the end-effector link.
+@return Random homogeneous transformation array within robot limits defined in the global link frame.
         """
         q = self.get_random_joint_positions()
         return self.get_global_link_transform(link_name, q)
@@ -826,9 +826,9 @@ class RobotModel(Model):
     def get_global_link_transform(self, link: str, q: ArrayType) -> CasADiArrayType:
         """! Get the link transform in the global frame for a given joint state q.
 
-        @param link Name of the end-effector link.
-        @param q Joint position array.
-        @return Homogeneous transform array.
+@param link Name of the end-effector link.
+@param q Joint position array.
+@return Homogeneous transform array.
         """
 
         # Setup
@@ -870,10 +870,10 @@ class RobotModel(Model):
     ) -> cs.Function:
         """! Get the function which computes the link transform in the global frame.
 
-        @param link Name of the end-effector link.
-        @param n Number of joint states to expect when the function is called. Default is 1.
-        @param numpy_output When true, the output will be a NumPy array.
-        @return A CasADi function that computes the transform for a given joint state. If n > 1 then a list of transform are given for each corresponding joint state.
+@param link Name of the end-effector link.
+@param n Number of joint states to expect when the function is called. Default is 1.
+@param numpy_output When true, the output will be a NumPy array.
+@return A CasADi function that computes the transform for a given joint state. If n > 1 then a list of transform are given for each corresponding joint state.
         """
         return self.make_function(
             "T", link, self.get_global_link_transform, n=n, numpy_output=numpy_output
@@ -886,10 +886,10 @@ class RobotModel(Model):
     ) -> CasADiArrayType:
         """! Get the link transform in a given base frame.
 
-        @param link Name of the end-effector link.
-        @param q Joint position array.
-        @param base_link Name of the base frame link.
-        @return Homogeneous transform array.
+@param link Name of the end-effector link.
+@param q Joint position array.
+@param base_link Name of the base frame link.
+@return Homogeneous transform array.
         """
         T_L_W = self.get_global_link_transform(link, q)
         T_B_W = self.get_global_link_transform(base_link, q)
@@ -904,11 +904,11 @@ class RobotModel(Model):
     ) -> CasADiArrayType:
         """! Get the function that computes the transform in a given base frame.
 
-        @param link Name of the end-effector link.
-        @param base_link Name of the base frame link.
-        @param n Number of joint states to expect when the function is called. Default is 1.
-        @param numpy_output When true, the output will be a NumPy array.
-        @return A CasADi function that computes the transform for a given joint state. If n > 1 then a list of transform are given for each corresponding joint state.
+@param link Name of the end-effector link.
+@param base_link Name of the base frame link.
+@param n Number of joint states to expect when the function is called. Default is 1.
+@param numpy_output When true, the output will be a NumPy array.
+@return A CasADi function that computes the transform for a given joint state. If n > 1 then a list of transform are given for each corresponding joint state.
         """
         return self.make_function(
             "T",
@@ -924,9 +924,9 @@ class RobotModel(Model):
     def get_global_link_position(self, link: str, q: ArrayType) -> CasADiArrayType:
         """! Get the link position in the global frame for a given joint state q.
 
-        @param link Name of the end-effector link.
-        @param q Joint position array.
-        @return Position array.
+@param link Name of the end-effector link.
+@param q Joint position array.
+@return Position array.
         """
         return transl(self.get_global_link_transform(link, q))
 
@@ -935,10 +935,10 @@ class RobotModel(Model):
     ) -> cs.Function:
         """! Get the function that computes the global position of a given link.
 
-        @param link Name of the end-effector link.
-        @param n Number of joint states to expect when the function is called. Default is 1.
-        @param numpy_output When true, the output will be a NumPy array.
-        @return A CasADi function that computes the position for a given joint state. If n > 1 then an array is computed whose columns each correspond to the respective joint state in the input.
+@param link Name of the end-effector link.
+@param n Number of joint states to expect when the function is called. Default is 1.
+@param numpy_output When true, the output will be a NumPy array.
+@return A CasADi function that computes the position for a given joint state. If n > 1 then an array is computed whose columns each correspond to the respective joint state in the input.
         """
         return self.make_function(
             "p", link, self.get_global_link_position, n=n, numpy_output=numpy_output
@@ -951,9 +951,9 @@ class RobotModel(Model):
     ) -> CasADiArrayType:
         """! Get the link position in a given base frame.
 
-        @param link Name of the end-effector link.
-        @param q Joint position array.
-        @return Position array.
+@param link Name of the end-effector link.
+@param q Joint position array.
+@return Position array.
         """
         return transl(self.get_link_transform(link, q, base_link))
 
@@ -966,11 +966,11 @@ class RobotModel(Model):
     ) -> cs.Function:
         """! Get the function that computes the position of a link in a given base frame.
 
-        @param link Name of the end-effector link.
-        @param base_link Name of the base frame link.
-        @param n Number of joint states to expect when the function is called. Default is 1.
-        @param numpy_output When true, the output will be a NumPy array.
-        @return A CasADi function that computes the position for a given joint state. If n > 1 then an array is computed whose columns each correspond to the respective joint state in the input.
+@param link Name of the end-effector link.
+@param base_link Name of the base frame link.
+@param n Number of joint states to expect when the function is called. Default is 1.
+@param numpy_output When true, the output will be a NumPy array.
+@return A CasADi function that computes the position for a given joint state. If n > 1 then an array is computed whose columns each correspond to the respective joint state in the input.
         """
         return self.make_function(
             "p",
@@ -986,9 +986,9 @@ class RobotModel(Model):
     def get_global_link_rotation(self, link: str, q: ArrayType) -> CasADiArrayType:
         """! Get the link rotation in the global frame for a given joint state q.
 
-        @param link Name of the end-effector link.
-        @param q Joint position array.
-        @return Rotation array.
+@param link Name of the end-effector link.
+@param q Joint position array.
+@return Rotation array.
         """
         return t2r(self.get_global_link_transform(link, q))
 
@@ -997,10 +997,10 @@ class RobotModel(Model):
     ) -> cs.Function:
         """! Get the function that computes a rotation matrix in the global link.
 
-        @param link Name of the end-effector link.
-        @param n Number of joint states to expect when the function is called. Default is 1.
-        @param numpy_output When true, the output will be a NumPy array.
-        @return A CasADi function that computes the rotation for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
+@param link Name of the end-effector link.
+@param n Number of joint states to expect when the function is called. Default is 1.
+@param numpy_output When true, the output will be a NumPy array.
+@return A CasADi function that computes the rotation for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
         """
         return self.make_function(
             "R", link, self.get_global_link_rotation, n=n, numpy_output=numpy_output
@@ -1013,10 +1013,10 @@ class RobotModel(Model):
     ) -> CasADiArrayType:
         """! Get the rotation matrix for a link in a given base frame.
 
-        @param link Name of the end-effector link.
-        @param q Joint position array.
-        @param base_link Name of the base frame link.
-        @return Rotation array.
+@param link Name of the end-effector link.
+@param q Joint position array.
+@param base_link Name of the base frame link.
+@return Rotation array.
         """
         return t2r(self.get_link_transform(link, q, base_link))
 
@@ -1029,11 +1029,11 @@ class RobotModel(Model):
     ) -> cs.Function:
         """! Get the function that computes the rotation matrix for a link in a given base frame.
 
-        @param link Name of the end-effector link.
-        @param base_link Name of the base frame link.
-        @param n Number of joint states to expect when the function is called. Default is 1.
-        @param numpy_output When true, the output will be a NumPy array.
-        @return A CasADi function that computes the rotation for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
+@param link Name of the end-effector link.
+@param base_link Name of the base frame link.
+@param n Number of joint states to expect when the function is called. Default is 1.
+@param numpy_output When true, the output will be a NumPy array.
+@return A CasADi function that computes the rotation for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
         """
         return self.make_function(
             "R",
@@ -1049,9 +1049,9 @@ class RobotModel(Model):
     def get_global_link_quaternion(self, link: str, q: ArrayType) -> CasADiArrayType:
         """! Get a quaternion in the global frame.
 
-        @param link Name of the end-effector link.
-        @param q Joint position array.
-        @return Quaternion array.
+@param link Name of the end-effector link.
+@param q Joint position array.
+@return Quaternion array.
         """
 
         # Setup
@@ -1090,10 +1090,10 @@ class RobotModel(Model):
     ) -> cs.Function:
         """! Get the function that computes a quaternion in the global frame.
 
-        @param link Name of the end-effector link.
-        @param n Number of joint states to expect when the function is called. Default is 1.
-        @param numpy_output When true, the output will be a NumPy array.
-        @return A CasADi function that computes the quaternion for a given joint state. If n > 1 then an array is computed whose columns correspond to the respective joint state in the input.
+@param link Name of the end-effector link.
+@param n Number of joint states to expect when the function is called. Default is 1.
+@param numpy_output When true, the output will be a NumPy array.
+@return A CasADi function that computes the quaternion for a given joint state. If n > 1 then an array is computed whose columns correspond to the respective joint state in the input.
         """
         return self.make_function(
             "quat",
@@ -1110,10 +1110,10 @@ class RobotModel(Model):
     ) -> CasADiArrayType:
         """! Get the quaternion defined in a given base frame.
 
-        @param link Name of the end-effector link.
-        @param q Joint position array.
-        @param base_link Name of the base frame link.
-        @return Quaternion array.
+@param link Name of the end-effector link.
+@param q Joint position array.
+@param base_link Name of the base frame link.
+@return Quaternion array.
         """
         quat_L_W = Quaternion.fromvec(self.get_global_link_quaternion(link, q))
         quat_B_W = Quaternion.fromvec(self.get_global_link_quaternion(base_link, q))
@@ -1128,11 +1128,11 @@ class RobotModel(Model):
     ) -> cs.Function:
         """! Get the function that computes a quaternion defined in a given base frame.
 
-        @param link Name of the end-effector link.
-        @param base_link Name of the base frame link.
-        @param n Number of joint states to expect when the function is called. Default is 1.
-        @param numpy_output When true, the output will be a NumPy array.
-        @return A CasADi function that computes the quaternion for a given joint state. If n > 1 then an array is computed whose columns correspond to the respective joint state in the input.
+@param link Name of the end-effector link.
+@param base_link Name of the base frame link.
+@param n Number of joint states to expect when the function is called. Default is 1.
+@param numpy_output When true, the output will be a NumPy array.
+@return A CasADi function that computes the quaternion for a given joint state. If n > 1 then an array is computed whose columns correspond to the respective joint state in the input.
         """
         return self.make_function(
             "quat",
@@ -1148,9 +1148,9 @@ class RobotModel(Model):
     def get_global_link_rpy(self, link: str, q: ArrayType) -> CasADiArrayType:
         """! Get the Roll-Pitch-Yaw angles in the global frame.
 
-        @param link Name of the end-effector link.
-        @param q Joint position array.
-        @return RPY euler angles in radians.
+@param link Name of the end-effector link.
+@param q Joint position array.
+@return RPY euler angles in radians.
         """
         return Quaternion.fromvec(self.get_global_link_quaternion(link, q)).getrpy()
 
@@ -1167,10 +1167,10 @@ class RobotModel(Model):
     def get_link_rpy(self, link: str, q: ArrayType, base_link: str) -> CasADiArrayType:
         """! Get the the Roll-Pitch-Yaw angles defined in a given base frame.
 
-        @param link Name of the end-effector link.
-        @param q Joint position array.
-        @param base_link Name of the base frame link.
-        @return RPY euler angles in radians.
+@param link Name of the end-effector link.
+@param q Joint position array.
+@param base_link Name of the base frame link.
+@return RPY euler angles in radians.
         """
         return Quaternion.fromvec(self.get_link_quaternion(link, q, base_link)).getrpy()
 
@@ -1179,11 +1179,11 @@ class RobotModel(Model):
     ) -> cs.Function:
         """! Get the function that computes the Roll-Pitch-Yaw angles defined in a given base frame.
 
-        @param link Name of the end-effector link.
-        @param base_link Name of the base frame link.
-        @param n Number of joint states to expect when the function is called. Default is 1.
-        @param numpy_output When true, the output will be a NumPy array.
-        @return A CasADi function that computes the RPY angles for a given joint state. If n > 1 then an array is computed whose columns correspond to the respective joint state in the input.
+@param link Name of the end-effector link.
+@param base_link Name of the base frame link.
+@param n Number of joint states to expect when the function is called. Default is 1.
+@param numpy_output When true, the output will be a NumPy array.
+@return A CasADi function that computes the RPY angles for a given joint state. If n > 1 then an array is computed whose columns correspond to the respective joint state in the input.
         """
         return self.make_function(
             "rpy",
@@ -1206,9 +1206,9 @@ class RobotModel(Model):
     ) -> CasADiArrayType:
         """! Compute the geometric Jacobian matrix in the global frame.
 
-        @param link Name of the end-effector link.
-        @param q Joint position array.
-        @return Geometric Jacobian.
+@param link Name of the end-effector link.
+@param q Joint position array.
+@return Geometric Jacobian.
         """
 
         e = self.get_global_link_position(link, q)
@@ -1281,10 +1281,10 @@ class RobotModel(Model):
     ) -> cs.Function:
         """! Get the function that computes the geometric jacobian in the global frame.
 
-        @param link Name of the end-effector link.
-        @param n Number of joint states to expect when the function is called. Default is 1.
-        @param numpy_output When true, the output will be a NumPy array.
-        @return A CasADi function that computes the geometric jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
+@param link Name of the end-effector link.
+@param n Number of joint states to expect when the function is called. Default is 1.
+@param numpy_output When true, the output will be a NumPy array.
+@return A CasADi function that computes the geometric jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
         """
         return self.make_function(
             "J", link, self.get_global_link_geometric_jacobian, n=n
@@ -1302,9 +1302,9 @@ class RobotModel(Model):
     ) -> CasADiArrayType:
         """! Compute the analytical Jacobian matrix in the global frame.
 
-        @param link Name of the end-effector link.
-        @param q Joint position array.
-        @return Analytic Jacobian.
+@param link Name of the end-effector link.
+@param q Joint position array.
+@return Analytic Jacobian.
         """
         return cs.vertcat(
             self.get_global_link_linear_jacobian(link, q),
@@ -1324,10 +1324,10 @@ class RobotModel(Model):
     ) -> cs.Function:
         """! Get the function that computes the analytical jacobian in the global frame.
 
-        @param link Name of the end-effector link.
-        @param n Number of joint states to expect when the function is called. Default is 1.
-        @param numpy_output When true, the output will be a NumPy array.
-        @return A CasADi function that computes the analytic jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
+@param link Name of the end-effector link.
+@param n Number of joint states to expect when the function is called. Default is 1.
+@param numpy_output When true, the output will be a NumPy array.
+@return A CasADi function that computes the analytic jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
         """
         return self.make_function(
             "J_a",
@@ -1349,10 +1349,10 @@ class RobotModel(Model):
     ) -> CasADiArrayType:
         """! Get the geometric jacobian in a given base link.
 
-        @param link Name of the end-effector link.
-        @param q Joint position array.
-        @param base_link Name of the base frame link.
-        @return Geometric Jacobian.
+@param link Name of the end-effector link.
+@param q Joint position array.
+@param base_link Name of the base frame link.
+@return Geometric Jacobian.
         """
 
         J = self.get_global_link_geometric_jacobian(link, q)
@@ -1382,11 +1382,11 @@ class RobotModel(Model):
     ) -> cs.Function:
         """Get the function that computes the geometric jacobian in a given base frame.
 
-        @param link Name of the end-effector link.
-        @param base_link Name of the base frame link.
-        @param n Number of joint states to expect when the function is called. Default is 1.
-        @param numpy_output When true, the output will be a NumPy array.
-        @return A CasADi function that computes the geometric jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
+@param link Name of the end-effector link.
+@param base_link Name of the base frame link.
+@param n Number of joint states to expect when the function is called. Default is 1.
+@param numpy_output When true, the output will be a NumPy array.
+@return A CasADi function that computes the geometric jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
         """
         return self.make_function(
             "J",
@@ -1409,10 +1409,10 @@ class RobotModel(Model):
     ) -> CasADiArrayType:
         """! Compute the analytical Jacobian matrix in a given base link.
 
-        @param link Name of the end-effector link.
-        @param q Joint position array.
-        @param base_link Name of the base frame link.
-        @return Analytic Jacobian.
+@param link Name of the end-effector link.
+@param q Joint position array.
+@param base_link Name of the base frame link.
+@return Analytic Jacobian.
         """
         return cs.vertcat(
             self.get_link_linear_jacobian(link, q, base_link),
@@ -1433,11 +1433,11 @@ class RobotModel(Model):
     ) -> cs.Function:
         """! Get the function that computes the analytical jacobian in a given base frame.
 
-        @param link Name of the end-effector link.
-        @param base_link Name of the base frame link.
-        @param n Number of joint states to expect when the function is called. Default is 1.
-        @param numpy_output When true, the output will be a NumPy array.
-        @return A CasADi function that computes the analytic jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
+@param link Name of the end-effector link.
+@param base_link Name of the base frame link.
+@param n Number of joint states to expect when the function is called. Default is 1.
+@param numpy_output When true, the output will be a NumPy array.
+@return A CasADi function that computes the analytic jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
         """
         return self.make_function(
             "J_a",
@@ -1460,9 +1460,9 @@ class RobotModel(Model):
     ) -> CasADiArrayType:
         """! Compute the linear part of the geometric jacobian in the global frame.
 
-        @param link Name of the end-effector link.
-        @param q Joint position array.
-        @return Linear part of the Jacobian.
+@param link Name of the end-effector link.
+@param q Joint position array.
+@return Linear part of the Jacobian.
         """
         J = self.get_global_link_geometric_jacobian(link, q)
         return J[:3, :]
@@ -1480,10 +1480,10 @@ class RobotModel(Model):
     ) -> cs.Function:
         """! Get the function that computes the linear part of the geometric jacobian in the global frame.
 
-        @param link Name of the end-effector link.
-        @param n Number of joint states to expect when the function is called. Default is 1.
-        @param numpy_output When true, the output will be a NumPy array.
-        @return A CasADi function that computes the linear part of the Jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
+@param link Name of the end-effector link.
+@param n Number of joint states to expect when the function is called. Default is 1.
+@param numpy_output When true, the output will be a NumPy array.
+@return A CasADi function that computes the linear part of the Jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
         """
         return self.make_function(
             "Jl",
@@ -1505,10 +1505,10 @@ class RobotModel(Model):
     ) -> CasADiArrayType:
         """! Get the linear part of the geometric jacobian in a given base frame.
 
-        @param link Name of the end-effector link.
-        @param q Joint position array.
-        @param base_link Name of the base frame link.
-        @return Linear part of the Jacobian.
+@param link Name of the end-effector link.
+@param q Joint position array.
+@param base_link Name of the base frame link.
+@return Linear part of the Jacobian.
         """
         J = self.get_link_geometric_jacobian(link, q, base_link)
         return J[:3, :]
@@ -1523,11 +1523,11 @@ class RobotModel(Model):
     ) -> cs.Function:
         """! Get the function that computes the linear part of the geometric jacobian in a given base frame.
 
-        @param link Name of the end-effector link.
-        @param base_link Name of the base frame link.
-        @param n Number of joint states to expect when the function is called. Default is 1.
-        @param numpy_output When true, the output will be a NumPy array.
-        @return A CasADi function that computes the linear part of the Jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
+@param link Name of the end-effector link.
+@param base_link Name of the base frame link.
+@param n Number of joint states to expect when the function is called. Default is 1.
+@param numpy_output When true, the output will be a NumPy array.
+@return A CasADi function that computes the linear part of the Jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
         """
         return self.make_function(
             "Jl",
@@ -1550,10 +1550,10 @@ class RobotModel(Model):
     ) -> CasADiArrayType:
         """! Compute the angular part of the geometric jacobian in the global frame.
 
-        @param link Name of the end-effector link.
-        @param q Joint position array.
-        @param base_link Name of the base frame link.
-        @return Angular part of the geometric Jacobian.
+@param link Name of the end-effector link.
+@param q Joint position array.
+@param base_link Name of the base frame link.
+@return Angular part of the geometric Jacobian.
         """
         J = self.get_global_link_geometric_jacobian(link, q)
         return J[3:, :]
@@ -1571,10 +1571,10 @@ class RobotModel(Model):
     ) -> cs.Function:
         """! Get the function that computes the angular part of the geometric jacobian in the global frame.
 
-        @param link Name of the end-effector link.
-        @param n Number of joint states to expect when the function is called. Default is 1.
-        @param numpy_output When true, the output will be a NumPy array.
-        @return A CasADi function that computes the angular part of the geometric Jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
+@param link Name of the end-effector link.
+@param n Number of joint states to expect when the function is called. Default is 1.
+@param numpy_output When true, the output will be a NumPy array.
+@return A CasADi function that computes the angular part of the geometric Jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
         """
         return self.make_function(
             "Ja",
@@ -1596,9 +1596,9 @@ class RobotModel(Model):
     ) -> CasADiArrayType:
         """! Compute the angular part of the analytical Jacobian matrix in the global frame.
 
-        @param link Name of the end-effector link.
-        @param q Joint position array.
-        @return Angular part of the analytical Jacobian.
+@param link Name of the end-effector link.
+@param q Joint position array.
+@return Angular part of the analytical Jacobian.
         """
         return self.get_link_angular_analytical_jacobian(link, q, self.get_root_link())
 
@@ -1615,10 +1615,10 @@ class RobotModel(Model):
     ) -> cs.Function:
         """! Get the function that computes the angular part of the analytical jacobian in the global frame.
 
-        @param link Name of the end-effector link.
-        @param n Number of joint states to expect when the function is called. Default is 1.
-        @param numpy_output When true, the output will be a NumPy array.
-        @return A CasADi function that computes the angular part of the geometric Jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
+@param link Name of the end-effector link.
+@param n Number of joint states to expect when the function is called. Default is 1.
+@param numpy_output When true, the output will be a NumPy array.
+@return A CasADi function that computes the angular part of the geometric Jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
         """
         return self.make_function(
             "Ja",
@@ -1640,10 +1640,10 @@ class RobotModel(Model):
     ) -> CasADiArrayType:
         """! Get the angular part of the geometric jacobian in a given base frame.
 
-        @param link Name of the end-effector link.
-        @param q Joint position array.
-        @param base_link Name of the base frame link.
-        @return Angular part of the geometric Jacobian.
+@param link Name of the end-effector link.
+@param q Joint position array.
+@param base_link Name of the base frame link.
+@return Angular part of the geometric Jacobian.
         """
         J = self.get_link_geometric_jacobian(link, q, base_link)
         return J[3:, :]
@@ -1662,11 +1662,11 @@ class RobotModel(Model):
     ) -> cs.Function:
         """! Get the function that computes the angular part of the geometric jacobian in a given base frame.
 
-        @param link Name of the end-effector link.
-        @param base_link Name of the base frame link.
-        @param n Number of joint states to expect when the function is called. Default is 1.
-        @param numpy_output When true, the output will be a NumPy array.
-        @return A CasADi function that computes the angular part of the geometric Jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
+@param link Name of the end-effector link.
+@param base_link Name of the base frame link.
+@param n Number of joint states to expect when the function is called. Default is 1.
+@param numpy_output When true, the output will be a NumPy array.
+@return A CasADi function that computes the angular part of the geometric Jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
         """
         return self.make_function(
             "Ja",
@@ -1689,10 +1689,10 @@ class RobotModel(Model):
     ) -> CasADiArrayType:
         """! Compute the angular part of the analytical Jacobian matrix in a given base frame.
 
-        @param link Name of the end-effector link.
-        @param q Joint position array.
-        @param base_link Name of the base frame link.
-        @return Angular part of the analytical Jacobian.
+@param link Name of the end-effector link.
+@param q Joint position array.
+@param base_link Name of the base frame link.
+@return Angular part of the analytical Jacobian.
         """
 
         # Compute rpy derivative Ja
@@ -1719,11 +1719,11 @@ class RobotModel(Model):
     ) -> cs.Function:
         """! Get the function that computes the angular part of the analytical jacobian in a given base frame.
 
-        @param link Name of the end-effector link.
-        @param base_link Name of the base frame link.
-        @param n Number of joint states to expect when the function is called. Default is 1.
-        @param numpy_output When true, the output will be a NumPy array.
-        @return A CasADi function that computes the angular part of the analytical Jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
+@param link Name of the end-effector link.
+@param base_link Name of the base frame link.
+@param n Number of joint states to expect when the function is called. Default is 1.
+@param numpy_output When true, the output will be a NumPy array.
+@return A CasADi function that computes the angular part of the analytical Jacobian for a given joint state. If n > 1 then a list of arrays are computed whose corresponding to the respective joint state in the input.
         """
         return self.make_function(
             "Ja",
@@ -1741,11 +1741,11 @@ class RobotModel(Model):
     ) -> CasADiArrayType:
         """! Compute the link axis, this is a direction vector defined in the end-effector frame (e.g. the x/y/z link axis).
 
-        @param link Name of the end-effector link.
-        @param q Joint position array.
-        @param axis The axis (direction vector) defined in the end-effector frame. If 'x', 'y', 'z' is passed then the corresponding sub-array of the homogenous transform is used.
-        @param base_link Name of the base frame link.
-        @return Axis defined in the end-effector frame as function of the joint angles.
+@param link Name of the end-effector link.
+@param q Joint position array.
+@param axis The axis (direction vector) defined in the end-effector frame. If 'x', 'y', 'z' is passed then the corresponding sub-array of the homogenous transform is used.
+@param base_link Name of the base frame link.
+@return Axis defined in the end-effector frame as function of the joint angles.
         """
         Tf = self.get_link_transform(link, q, base_link)
 
@@ -1779,11 +1779,11 @@ class RobotModel(Model):
     ) -> cs.Function:
         """! Get function for computing the link axis.
 
-        @param link Name of the end-effector link.
-        @param axis The axis (direction vector) defined in the end-effector frame. If 'x', 'y', 'z' is passed then the corresponding sub-array of the homogenous transform is used.
-        @param base_link Name of the base frame link.
-        @param numpy_output When true, the output will be a NumPy array.
-        @return A CasADi function that computes the link axis for a given joint state. If n > 1 then an array is computed whose columns correspond to the respective joint state in the input.
+@param link Name of the end-effector link.
+@param axis The axis (direction vector) defined in the end-effector frame. If 'x', 'y', 'z' is passed then the corresponding sub-array of the homogenous transform is used.
+@param base_link Name of the base frame link.
+@param numpy_output When true, the output will be a NumPy array.
+@return A CasADi function that computes the link axis for a given joint state. If n > 1 then an array is computed whose columns correspond to the respective joint state in the input.
         """
         return self.make_function(
             "a",
@@ -1802,10 +1802,10 @@ class RobotModel(Model):
     ) -> CasADiArrayType:
         """! Compute the link axis, this is a direction vector defined in the end-effector frame (e.g. the x/y/z link axis) in the global frame.
 
-        @param link Name of the end-effector link.
-        @param q Joint position array.
-        @param axis The axis (direction vector) defined in the end-effector frame. If 'x', 'y', 'z' is passed then the corresponding sub-array of the homogenous transform is used.
-        @return Axis defined in the end-effector frame as function of the joint angles.
+@param link Name of the end-effector link.
+@param q Joint position array.
+@param axis The axis (direction vector) defined in the end-effector frame. If 'x', 'y', 'z' is passed then the corresponding sub-array of the homogenous transform is used.
+@return Axis defined in the end-effector frame as function of the joint angles.
         """
         return self.get_link_axis(link, q, axis, self.get_root_link())
 
@@ -1818,10 +1818,10 @@ class RobotModel(Model):
     ) -> cs.Function:
         """! Get function for computing the link axis in the global frame.
 
-        @param link Name of the end-effector link.
-        @param axis The axis (direction vector) defined in the end-effector frame. If 'x', 'y', 'z' is passed then the corresponding sub-array of the homogenous transform is used.
-        @param numpy_output When true, the output will be a NumPy array.
-        @return A CasADi function that computes the link axis for a given joint state. If n > 1 then an array is computed whose columns correspond to the respective joint state in the input.
+@param link Name of the end-effector link.
+@param axis The axis (direction vector) defined in the end-effector frame. If 'x', 'y', 'z' is passed then the corresponding sub-array of the homogenous transform is used.
+@param numpy_output When true, the output will be a NumPy array.
+@return A CasADi function that computes the link axis for a given joint state. If n > 1 then an array is computed whose columns correspond to the respective joint state in the input.
         """
         get_global_link_axis = functools.partial(self.get_global_link_axis, axis=axis)
         return self.make_function(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -474,6 +474,17 @@ class TestRobotModel:
                     T_expc = expected_fkine[link_idx + 1]
                     assert isclose(T_test, T_expc)
 
+    def test_get_global_link_transform_function_numpy_output(self):
+        link_name = self.model.link_names[-1]
+        q = self.model.get_random_joint_positions().toarray()
+        Tr = self.model.get_global_link_transform_function(link_name, numpy_output=True)
+        T = Tr(q)
+        assert isinstance(T, np.ndarray)
+
+        q = optas.SX.sym("q", q.shape[0])
+        with pytest.raises(AssertionError):
+            T = Tr(q)
+
     def test_get_link_transform(self):
         for _ in range(NUM_RANDOM):
             q = self.model.get_random_joint_positions().toarray().flatten()


### PR DESCRIPTION
**Motivation**

The benefit of this is when the user creates functions that they want to evaluate later (this is assuming you don't pass symbolic variables). For example, when I want the wrench at the end-effector from the joint, I want a function to evaluate the Jacobian. Since I am not defining an optimization problem, I will be doing the computation in Numpy (faster than casadi DM).

**Difference**

Before
```python
robot = optas.RobotModel(...)
pos = robot.get_global_link_position_function(ee_link)

p = pos(q).toarray().flatten()  # pos(q) outputs a casadi.DM array
```

After
```python
robot = optas.RobotModel(...)
pos = robot.get_global_link_position_function(ee_link, numpy_output=True)

p = pos(q)  # since numpy_output=True is specified, the output is automatically converted to a numpy array
```

When `numpy_output=True` is specified, if you pass a symbolic variable in then the method will fail since you are telling optas that you are expecting not to be passing symbolic variables.

**Todo before merge**

- [x] Add unit tests
- [x] Add documentation
- [x] Approval from @joaomoura24 